### PR TITLE
Fix Fosstodon references

### DIFF
--- a/data/team/algent.yaml
+++ b/data/team/algent.yaml
@@ -11,5 +11,5 @@ social:
   irc: "algent"
   reddit: "algent-al"
   twitter: "al_genti"
-  fosstodon: "@algent@fosstodon.org"
+  fosstodon: "@algent"
 active: true

--- a/data/team/staudey.yaml
+++ b/data/team/staudey.yaml
@@ -10,5 +10,5 @@ social:
   github: "Staudey"
   irc: "Staudey"
   reddit: "Staudey"
-  fosstodon: "@staudey@fosstodon.org"
+  fosstodon: "@staudey"
 active: true


### PR DESCRIPTION
Accounts hosted directly on Fosstodon don't seem to load if you append "@fosstodon.org"