### PR TITLE
branding: fix link to press center

### DIFF
--- a/content/branding.html
+++ b/content/branding.html
@@ -1,6 +1,6 @@
 +++
 title = "branding"
-date = "2017-01-07T02:44:48+00:00"
+date = "2023-06-08T13:55:34+02:00"
 +++
 
 <div class="narrow">
@@ -10,7 +10,7 @@ date = "2017-01-07T02:44:48+00:00"
   <p>
     We enforce branding guidelines to ensure consistency of imaging and
     messaging for Solus and its software. If you have any questions, please
-    consult our <a href="/press-center/">Press Center</a>).
+    consult our <a href="/press/">Press Center</a>).
   </p>
 
   <h2>Assets</h2>


### PR DESCRIPTION
This page was still using the old link, leading to a 404

I found some other issues that I'm not sure how to properly fix, so will create an issue about them instead.