### PR TITLE
tracey.yaml: fix Fosstodon reference

### DIFF
--- a/data/team/tracey.yaml
+++ b/data/team/tracey.yaml
@@ -11,6 +11,6 @@ teams:
 social:
   github: "TraceyC77"
   irc: "TraceyC"
-  fosstodon: "TraceyC@fosstodon.org"
+  fosstodon: "@TraceyC"
   www: "https://www.tlcnet.info"
 active: true


### PR DESCRIPTION
Doesn't need the explicit @fosstodon.org (this would cause it to double after formatting)