### PR TITLE
Branding: remove stray parenthesis

### DIFF
--- a/content/branding.html
+++ b/content/branding.html
@@ -1,6 +1,6 @@
 +++
 title = "branding"
-date = "2023-06-08T13:55:34+02:00"
+date = "2024-01-30T20:34:39+01:00"
 +++
 
 <div class="narrow">
@@ -10,7 +10,7 @@ date = "2023-06-08T13:55:34+02:00"
   <p>
     We enforce branding guidelines to ensure consistency of imaging and
     messaging for Solus and its software. If you have any questions, please
-    consult our <a href="/press/">Press Center</a>).
+    consult our <a href="/press/">Press Center</a>.
   </p>
 
   <h2>Assets</h2>
@@ -44,8 +44,8 @@ date = "2023-06-08T13:55:34+02:00"
 
   <h3>Copyright</h3>
   <ul>
-    <li>Solus Logo: Copyright © 2016-2023 Solus Project.</li>
-    <li>“Solus” Name: Copyright © 2011-2023 Solus Project.</li>
+    <li>Solus Logo: Copyright © 2016-2024 Solus Project.</li>
+    <li>“Solus” Name: Copyright © 2011-2024 Solus Project.</li>
   </ul>
 
   <h3>Licensing</h3>


### PR DESCRIPTION
This removes a stray parenthesis at the end of the first paragraph on the Branding page.
It also updates the copyright to 2024 on that page while we're at it.