### PR TITLE
Update requirements location

### DIFF
--- a/themes/solus/layouts/shortcodes/pages/download.html
+++ b/themes/solus/layouts/shortcodes/pages/download.html
@@ -28,16 +28,13 @@
         <section class="more">
             <h2> More Information </h1>
             <h4> System Requirements </h4>
-            <ul>
-                <li> A blank DVD or a 3GB USB drive. </li>
-                <li> Minimum of 10GB of disk space available. </li>
-                <li> 4GB of RAM for an optimal experience. </li>
-                <li> A 64-bit (x86_64) processor. </li>
-            </ul>
+            <p>
+                Ensure your system meets <a href="https://help.getsol.us/docs/user/quick-start/installation/system-requirements">our installation requirements</a>!
+            </p>
 
             <h4> Need assistance? </h4>
             <p>
-                Feel free to reach out on our <a href="https://matrix.to/#/#solus:matrix.org">Matrix chat rooms</a>!
+                Feel free to reach out on our <a href="https://matrix.to/#/#solus:matrix.org"> Support room on Matrix chat</a>!
             </p>
             {{ partial "donate" }}
 		</section>


### PR DESCRIPTION
Change the Downloads page to link to new requirements page in the Help Center rather than display the info directly
    
Related to /getsolus/help-center-docs/issues/506
