### PR TITLE
blog: Use standard summaryLength or explicit summary length (if set)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -14,6 +14,7 @@ defaultContentLanguageInSubdir = false
 googleanalytics = "UA-Not-Yet"
 metaDataFormat = "toml"
 pagination.pagerSize = 5
+summaryLength = 25
 theme = ["blog", "solus"]
 enableInlineShortcodes = true
 

--- a/themes/blog/layouts/blog/list.html
+++ b/themes/blog/layouts/blog/list.html
@@ -8,16 +8,12 @@
 		<meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="{{ $firstBlog.Permalink | absURL }}"/>
 		<section>
 			{{ partial "blog/info.html" (dict "blog" $firstBlog "site" .Site) }}
-			{{ if ge (len $firstBlog.Summary) 397 }}
-				<p itemprop="description">{{- htmlUnescape (plainify (safeHTML (substr $firstBlog.Summary 0 187))) -}}...</p>
-			{{ else }}
-				<p itemprop="description">{{- htmlUnescape (plainify (safeHTML $firstBlog.Summary)) -}}</p>
-			{{ end }}
-					<div class="menu">
-							<nav>
+			<div itemprop="description">{{- safeHTML $firstBlog.Summary -}}</div>
+				<div class="menu">
+					<nav>
 						<a class="button inverse" href="{{ $firstBlog.Permalink }}">Read More</a>
-							</nav>
-					</div>
+					</nav>
+				</div>
 		</section>
 		{{ $url := (printf "%s/%s" $firstBlog.Params.url $firstBlog.Params.featuredimage) | absURL }}
         <img alt="{{ $firstBlog.Title }}" src="{{ $url }}"></img>


### PR DESCRIPTION
This removes some manual overrides of the summary length for blog posts and instead relies on the `summaryLength` hugo parameter where it's not manually set, and uses the manually set summary length set in single blog posts (via `<!--more-->`).

Also allow paragraph html elements in the summary

25 seemed a good value for the default summary length in my testing

Resolves #41