### PR TITLE
Remove mailto link in copyright footer

### DIFF
--- a/themes/solus/layouts/partials/footer.html
+++ b/themes/solus/layouts/partials/footer.html
@@ -24,7 +24,7 @@
 	{{ end }}
     <div class="legal">
 		<p>
-			Copyright <a href="mailto:copyright@getsol.us">&copy; 2015-{{ .Site.Params.copyright }} Solus Project</a>. The Solus logo is Copyright <a href="mailto:copyright@getsol.us">&copy; 2015-{{ .Site.Params.copyright }} Solus Project</a>. All rights reserved.
+			Copyright &copy; 2015-{{ .Site.Params.copyright }} Solus Project. The Solus logo is Copyright &copy; 2015-{{ .Site.Params.copyright }} Solus Project. All rights reserved.
         </p>
         <p>
             Laptop graphic provided by Clyde Goodall. <br />


### PR DESCRIPTION
The footer currently contains a `mailto` link to an address we do not use. Many other ways of contacting the team are available on the website.