### PR TITLE
css: Move section CSS classes out of shortcode

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3,3 +3,19 @@
 @source "hugo_stats.json";
 
 @custom-variant dark (&:where(.dark, .dark *));
+
+.solus-section:not(.alt) {
+    @apply w-full max-w-[90rem] pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-left),1.5rem)] mx-auto;
+}
+
+.solus-section.alt {
+    @apply not-dark:bg-gray-100 bg-neutral-900 w-full py-10 md:py-12 lg:py-14 border-t border-b border-neutral-300/75 dark:border-neutral-700/75;
+}
+
+.solus-section:not(.alt) > .solus-section-inner {
+    @apply w-full py-10 md:py-12 lg:py-14;
+}
+
+.solus-section.alt > .solus-section-inner {
+    @apply max-w-[90rem] pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-left),1.5rem)] mx-auto;
+}

--- a/layouts/_partials/components/team.html
+++ b/layouts/_partials/components/team.html
@@ -4,8 +4,8 @@
 {{- $alt := .alt -}}
 
 {{- if eq $alt true -}}
-<section class="not-dark:bg-gray-100 bg-neutral-900 w-full py-10 md:py-12 lg:py-14 border-t border-b border-neutral-300/75 dark:border-neutral-700/75">
-    <div class="max-w-[90rem] pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-left),1.5rem)] mx-auto">
+<section class="solus-section alt">
+    <div class="solus-section-inner">
         <h2 class="text-4xl md:text-3xl font-semibold mb-10 text-(--color-primary-500)">{{ $name }}</h2>
         <p class="mb-5">{{ $description | markdownify }}</p>
         <div class="hextra-cards mt-4 gap-8 grid not-prose" style="--hextra-cards-grid-cols: 2;">
@@ -26,8 +26,8 @@
     </div>
 </section>
 {{- else -}}
-<div class="max-w-[90rem] pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-left),1.5rem)] mx-auto">
-    <section class="w-full py-10 md:py-12 lg:py-14">
+<div class="solus-section">
+    <section class="solus-section-inner">
         <h2 class="text-4xl md:text-3xl font-semibold mb-10 text-(--color-primary-500)">{{ $name }}</h2>
         <p class="mb-5">{{ $description | markdownify }}</p>
         <div class="hextra-cards mt-4 gap-8 grid not-prose" style="--hextra-cards-grid-cols: 2;">

--- a/layouts/_shortcodes/section.html
+++ b/layouts/_shortcodes/section.html
@@ -2,15 +2,15 @@
 {{- $alt := .Get "alt" | default false -}}
 
 {{- if eq $alt true -}}
-    <section class="not-dark:bg-gray-100 bg-neutral-900 w-full py-10 md:py-12 lg:py-14 border-t border-b border-neutral-300/75 dark:border-neutral-700/75">
-        <div class="max-w-[90rem] pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-left),1.5rem)] mx-auto">
+    <section class="solus-section alt">
+        <div class="solus-section-inner">
             <h2 class="text-4xl md:text-3xl font-semibold mb-10 text-(--color-primary-500)">{{ $heading }}</h2>
             {{ .Inner }}
         </div>
     </section>
 {{- else -}}
-    <div class="w-full max-w-[90rem] pl-[max(env(safe-area-inset-left),1.5rem)] pr-[max(env(safe-area-inset-left),1.5rem)] mx-auto">
-        <section class="w-full py-10 md:py-12 lg:py-14">
+    <div class="solus-section">
+        <section class="solus-section-inner">
             <h2 class="text-4xl md:text-3xl font-semibold mb-10 text-(--color-primary-500)">{{ $heading }}</h2>
             {{ .Inner }}
         </section>


### PR DESCRIPTION
This means that if we change a class in `section`, we don't have to remember to also change it in `team`.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
