### PR TITLE
Use a double-quoted string to fix yaml error

### DIFF
--- a/content/blog/2026/05/clearing-up-the-fog/index.md
+++ b/content/blog/2026/05/clearing-up-the-fog/index.md
@@ -11,7 +11,7 @@ tags:
 date: '2026-05-11T10:00:00+07:00'
 title: 'Clearing up the Fog'
 url: /2026/05/clearing-up-the-fog
-summary: 'Hello everyone! We want to talk about our licensing situation and our plan regarding it. Let's dive in!'
+summary: "Hello everyone! We want to talk about our licensing situation and our plan regarding it. Let's dive in!"
 ---
 ![](clearing-up-the-fog-banner.jpg "Morning fog at some trees by Keravanjoki river in Vantaa, Finland")
 


### PR DESCRIPTION
Deployment faiiled because single-quoted string with a single quote in it. Fixor