### PR TITLE
correction: Add a shortcode for a element highlighting a correction

### DIFF
--- a/content/blog/2025/11/solus-4.8-released/index.md
+++ b/content/blog/2025/11/solus-4.8-released/index.md
@@ -136,6 +136,10 @@ Head on over to our [Download](/download) page to download the edition you wish 
 
 We want to give a shout-out to all of our supporters on [OpenCollective](https://opencollective.com/getsolus). We are grateful to all of our backers who fund our work, and help us bring this Linux distribution to everyone. Solus could not operate without your help. Your donations pay for our server infrastructure, services like email, and our contributors for long-term and complex package and development work. You can [become a backer](https://opencollective.com/getsolus#category-CONTRIBUTE) today for as little as $1 a month. Thank you.
 
-*A previous version of this post listed an incorrect version of LibreOffice. It has been corrected to 25.2.6.*
+{{< correction date="29 Nov 2025" >}}
+  A previous version of this post listed an incorrect version of LibreOffice. It has been corrected to 25.2.6.
+{{< /correction >}}
 
-*A previous version of this post stated that Plasma 6.8 would release in early 2027. It has been corrected to say October 2026.*
+{{< correction date="29 Nov 2025" >}}
+  A previous version of this post stated that Plasma 6.8 would release in early 2027. It has been corrected to say October 2026.
+{{< /correction >}}

--- a/content/blog/2026/04/solus-4.9-released/index.md
+++ b/content/blog/2026/04/solus-4.9-released/index.md
@@ -120,4 +120,6 @@ Head on over to our [Download](/download) page to download the edition you wish 
 
 We want to give a shout-out to all of our supporters on [OpenCollective](https://opencollective.com/getsolus). We are grateful to all of our backers who fund our work, and help us bring this Linux distribution to everyone. Solus could not operate without your help. Your donations pay for our server infrastructure and services like email. They also help reimburse contributors for long-term and complex package and development work. You can [become a backer](https://opencollective.com/getsolus#category-CONTRIBUTE) today for as little as $1 a month. Thank you.
 
-*A previous version of this post was missing a warning about Budgie and X11. A warning has been added.*
+{{< correction date="18 Apr 2026" >}}
+  A previous version of this post was missing a warning about Budgie and X11. A warning has been added.
+{{< /correction >}}

--- a/layouts/_partials/components/correction.html
+++ b/layouts/_partials/components/correction.html
@@ -1,0 +1,11 @@
+{{- $content := .content -}}
+{{- $date := .date | default .Lastmod -}}
+
+{{ $datetime := (time.Format "2006-01-02T15:04:05.000Z" $date) }}
+
+<div class="bg-neutral-100 dark:bg-neutral-800 font-[400] text-sm text-neutral-600 dark:text-neutral-400">
+  <h5 class="pl-4 pr-4 pt-4 pb-1">Correction
+    <time class="block mt-6 text-base/4" datetime={{ $datetime }}>{{ partial "utils/format-date" $date }}</span>
+  </h5>
+  <p class="not-prose mt-2 pl-4 pr-4 pb-4">{{ $content }}</p>
+</div>

--- a/layouts/_shortcodes/correction.html
+++ b/layouts/_shortcodes/correction.html
@@ -1,0 +1,10 @@
+{{- $content := .InnerDeindent | markdownify -}}
+{{- $date := .Get "date" | default "" -}}
+
+{{- $parsedDate := time.AsTime $date -}}
+
+{{- partial "components/correction.html" (dict
+  "date" $parsedDate
+  "content" $content
+  )
+-}}


### PR DESCRIPTION
Sometimes, it is necessary to update a blog post with some sort of correction to the content. In the interests of transparency, we want to show in the post that such a correction has been made, and why. This new shortcode makes doing this really easy, and consistent.

<img width="740" height="392" alt="image" src="https://github.com/user-attachments/assets/0d7c8b21-6230-4fcc-b09d-68aa1af9e56f" />


Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
